### PR TITLE
Fixing a issue when the gevent worker is using an inexistent log.

### DIFF
--- a/pistil/tcp/gevent_worker.py
+++ b/pistil/tcp/gevent_worker.py
@@ -7,7 +7,8 @@ from __future__ import with_statement
 
 import os
 import sys
-
+import logging
+log = logging.getLogger(__name__)
 
 try:
     import gevent
@@ -58,7 +59,7 @@ class TcpGeventWorker(TcpSyncWorker):
             while self.alive:
                 self.notify()
                 if self.ppid != os.getppid():
-                    self.log.info("Parent changed, shutting down: %s", self)
+                    log.info("Parent changed, shutting down: %s", self)
                     break
         
                 gevent.sleep(1.0)


### PR DESCRIPTION
Fixing a issue when the gevent worker is using an inexistent log facility.
